### PR TITLE
Fix toolbar of pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,7 +2,6 @@ url: http://www.schlosslab.org/clustur/
 template:
   bootstrap: 5
   light-switch: true
-  bootswatch: materia
 reference:
 - title: Clustering
   contents:
@@ -25,11 +24,3 @@ reference:
   - validate_count_table
   - create_sparse_matrix
   - split_clusters_to_list
-navbar:
-  type: default
-  left:
-  - text: clustur
-    href: articles/clustur.html
-  - text: Reference
-    href: reference/index.html
-


### PR DESCRIPTION
* There should be a "Getting started" and "References" link in the navbar. These are getting replaced with what was at the bottom
* The "materia" theme was too thick and covering text in the rest of the page (at least with Chrome)