### PR TITLE
Make link to clustur.html an absolute link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ library(clustur)
 ## Getting Started
 
 To get started, look at the [“Getting
-started”](www.schlosslab.org/clustur/) page.
+started”](https:://www.schlosslab.org/clustur/) page.
 
 ## Contributions
 


### PR DESCRIPTION
Was creating a link "https://www.schlosslab.org/clustur/www.schlosslab.org/clustur/" behind "Getting started"