### PR TITLE
Fix duplicated names during opticluster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: clustur
 Type: Package
 Title: Clustering
-Version: 0.1.2
-Date: 2025-04-12
+Version: 0.1.3
+Date: 2025-04-15
 Authors@R: c(
     person("Gregory", "Johnson", , "grejoh@umich.edu", role = c("aut"),
             comment = c(ORCID = "0009-0008-3890-0297")),

--- a/src/OptimatrixAdapter.cpp
+++ b/src/OptimatrixAdapter.cpp
@@ -26,8 +26,8 @@ OptiMatrix* OptimatrixAdapter::ConvertToOptimatrix(const SparseDistanceMatrix* m
     int nameOffset = 0;
     std::vector<std::unordered_set<long long>> closeness(nonSingletonCount);
     for(const auto& cell : matrixData->seqVec) {
-         const std::string name =listVector->get(count + nameOffset);
-         nameList[count + nameOffset] = name;
+        const std::string name = listVector->get(count + nameOffset);
+        // nameList[count + nameOffset] = name;
         if(cell.empty()) {
             singletons.emplace_back(name);
             nameOffset++;
@@ -43,6 +43,7 @@ OptiMatrix* OptimatrixAdapter::ConvertToOptimatrix(const SparseDistanceMatrix* m
             }
             if(distance <= cutoff) {
                 cells.insert(indexSwap[row.index]);
+                nameList[row.index] = listVector->get(row.index);
             }
         }
         closeness[count] = cells;

--- a/src/OptimatrixAdapter.cpp
+++ b/src/OptimatrixAdapter.cpp
@@ -43,7 +43,7 @@ OptiMatrix* OptimatrixAdapter::ConvertToOptimatrix(const SparseDistanceMatrix* m
             }
             if(distance <= cutoff) {
                 cells.insert(indexSwap[row.index]);
-                nameList[row.index] = listVector->get(row.index);
+                nameList[indexSwap[row.index]] = listVector->get(row.index);
             }
         }
         closeness[count] = cells;

--- a/tests/testthat/test-test-opticluster.R
+++ b/tests/testthat/test-test-opticluster.R
@@ -10,7 +10,121 @@ test_that("opticluster returns four dataframes", {
   expect_equal(class(df$iteration_metrics), "data.frame")
   expect_equal(class(df$abundance), "data.frame")
   expect_true(all(csv$label == df$label))
+
 })
+
+test_that("opticluster and other clustering methods do not cluster duplicate values with column files", {
+  cutoff <- 0.2
+  count_table <- read_count(test_path("extdata", "amazon.count_table"))
+  distance_data <- read_dist(test_path("extdata", "amazon_column.dist"),
+                             count_table, cutoff, FALSE)
+  df <- cluster(distance_data, cutoff, method = "opticlust")
+
+  list_data <- clustur::split_clusters_to_list(df)
+  count <- 0
+  ls <- c()
+  for(i in list_data){
+    ls <- c(ls, i)
+  }
+  expect_true(length(ls[which(duplicated(ls))]) <= 0)
+  expect_true(length(unique(ls)) == length(ls))
+
+  # Works also when not opticluster
+  # Since furthest, nearest, average, and weighted all
+  # follow the same structure, I do not need
+  # to test them all individually
+  # We will use nearest...
+
+  df <- cluster(distance_data, cutoff, method = "nearest")
+
+  list_data <- clustur::split_clusters_to_list(df)
+  count <- 0
+  ls <- c()
+  for(i in list_data){
+    ls <- c(ls, i)
+  }
+  expect_true(length(ls[which(duplicated(ls))]) <= 0)
+  expect_true(length(unique(ls)) == length(ls))
+  
+})
+
+test_that("opticluster and other clustering methods do not cluster duplicate values with phylip files", {
+  cutoff <- 0.2
+  count_table <- read_count(test_path("extdata", "amazon.count_table"))
+  distance_data <- read_dist(test_path("extdata", "amazon_phylip.dist"),
+                             count_table, cutoff, FALSE)
+  df <- cluster(distance_data, cutoff, method = "opticlust")
+
+  list_data <- clustur::split_clusters_to_list(df)
+  count <- 0
+  ls <- c()
+  for(i in list_data){
+    ls <- c(ls, i)
+  }
+  expect_true(length(ls[which(duplicated(ls))]) <= 0)
+  expect_true(length(unique(ls)) == length(ls))
+
+  
+  # Works also when not opticluster
+  # Since furthest, nearest, average, and weighted all
+  # follow the same structure, I do not need
+  # to test them all individually
+  # We will use nearest...
+
+  df <- cluster(distance_data, cutoff, method = "nearest")
+
+  list_data <- clustur::split_clusters_to_list(df)
+  count <- 0
+  ls <- c()
+  for(i in list_data){
+    ls <- c(ls, i)
+  }
+  expect_true(length(ls[which(duplicated(ls))]) <= 0)
+  expect_true(length(unique(ls)) == length(ls))
+  
+})
+
+test_that("opticluster and other clustering methods do not cluster duplicate values with a sparse matrix", {
+  cutoff <- 0.2
+  i_values <- as.integer(1:100)
+  j_values <- as.integer(sample(1:100, 100, TRUE))
+  x_values <- as.numeric(runif(100, 0, 1))
+  s_matrix <- create_sparse_matrix(i_values, j_values, x_values)
+  sparse_count <- data.frame(Representative_Sequence = 1:100,
+                             total = rep(1, times = 100))
+  distance_data <- read_dist(s_matrix, sparse_count, 0.2, FALSE)
+  df <- cluster(distance_data, cutoff, method = "opticlust")
+
+  list_data <- clustur::split_clusters_to_list(df)
+  count <- 0
+  ls <- c()
+  for(i in list_data){
+    ls <- c(ls, i)
+  }
+  expect_true(length(ls[which(duplicated(ls))]) <= 0)
+  expect_true(length(unique(ls)) == length(ls))
+
+  # Works also when not opticluster
+  # Since furthest, nearest, average, and weighted all
+  # follow the same structure, I do not need
+  # to test them all individually
+  # We will use nearest...
+
+  df <- cluster(distance_data, cutoff, method = "nearest")
+
+  list_data <- clustur::split_clusters_to_list(df)
+  count <- 0
+  ls <- c()
+  for(i in list_data){
+    ls <- c(ls, i)
+  }
+  expect_true(length(ls[which(duplicated(ls))]) <= 0)
+  expect_true(length(unique(ls)) == length(ls))
+
+})
+
+
+
 
 test_that("other clustering methods only return two dataframes", {
   cutoff <- 0.2


### PR DESCRIPTION
There was a big issue where the names of the count table would be duplicated during the clustering process. This PR should address that issue. 